### PR TITLE
Get Token Exemple

### DIFF
--- a/dotnet/ReadMe.md
+++ b/dotnet/ReadMe.md
@@ -32,6 +32,23 @@ Here is how to get an instance of CRMWebAPI passing an ADAL with a user and pass
   }
 ````
 
+Here is how to get an instance of CRMWebAPI passing an ADAL with a Server-to-server authentication - to understand how to get a client ID visit the walk through here https://msdn.microsoft.com/en-us/library/mt622431.aspx 
+````
+  public async static Task<CRMWebAPI> GetAPI()
+  {
+      string authority = "https://login.microsoftonline.com/";
+      string clientId = "<clientid>";
+      string crmBaseUrl = "https://xx.crm.dynamics.com";
+      string clientSecret = "<clientSecret>";
+      string tenantID = "<tenantId>>";     
+      var clientcred = new ClientCredential(clientId, clientSecret);
+      var authContext = new AuthenticationContext(authority + tenantID);
+      var authenticationResult = await authContext.AcquireTokenAsync(crmBaseUrl, clientcred);
+  
+      return new CRMWebAPI(crmBaseUrl + "/api/data/v8.0/", authenticationResult.AccessToken);
+  }
+````
+
 Here are a few simple examples 
 ````
         Task.Run(async () =>

--- a/dotnet/ReadMe.md
+++ b/dotnet/ReadMe.md
@@ -32,8 +32,7 @@ Here is how to get an instance of CRMWebAPI passing an ADAL with a user and pass
   }
 ````
 
-Here is how to get an instance of CRMWebAPI passing an ADAL with a Server-to-server authentication - to understand how to get a client ID visit the walk through here https://msdn.microsoft.com/en-us/library/mt622431.aspx 
-To understand Server-to-server authentication visit
+Here is how to get an instance of CRMWebAPI passing an ADAL with a Server-to-server authentication - to understand Server-to-server authentication visit
 https://msdn.microsoft.com/en-us/library/mt790168.aspx
 ````
   public async static Task<CRMWebAPI> GetAPI()

--- a/dotnet/ReadMe.md
+++ b/dotnet/ReadMe.md
@@ -33,6 +33,8 @@ Here is how to get an instance of CRMWebAPI passing an ADAL with a user and pass
 ````
 
 Here is how to get an instance of CRMWebAPI passing an ADAL with a Server-to-server authentication - to understand how to get a client ID visit the walk through here https://msdn.microsoft.com/en-us/library/mt622431.aspx 
+To understand Server-to-server authentication visit
+https://msdn.microsoft.com/en-us/library/mt790168.aspx
 ````
   public async static Task<CRMWebAPI> GetAPI()
   {
@@ -40,7 +42,8 @@ Here is how to get an instance of CRMWebAPI passing an ADAL with a Server-to-ser
       string clientId = "<clientid>";
       string crmBaseUrl = "https://xx.crm.dynamics.com";
       string clientSecret = "<clientSecret>";
-      string tenantID = "<tenantId>>";     
+      string tenantID = "<tenantId>"; 
+
       var clientcred = new ClientCredential(clientId, clientSecret);
       var authContext = new AuthenticationContext(authority + tenantID);
       var authenticationResult = await authContext.AcquireTokenAsync(crmBaseUrl, clientcred);


### PR DESCRIPTION
This exemple implements the new "AcquireTokenAsync" with Server-To-Server authentication.

The UserCredential is not available anymore in .Net Core

https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/482