### PR TITLE
Adjust response object attributes.

### DIFF
--- a/dotnet/Xrm.Tools.WebAPI/Requests/CRMWebAPIConfig.cs
+++ b/dotnet/Xrm.Tools.WebAPI/Requests/CRMWebAPIConfig.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Xrm.Tools.WebAPI.Requests
@@ -11,10 +8,10 @@ namespace Xrm.Tools.WebAPI.Requests
     {
         public string APIUrl { get; set; }
         public string AccessToken { get; set; }
+        public bool ResolveUnicodeNames { get; set; }
         public Guid CallerID { get; set; }
         public Func<string, Task<string>> GetAccessToken { get; set; }
         public NetworkCredential   NetworkCredential { get; set; }
-
         public CRMWebAPILoggingOptions Logging { get; set; }
 
     }


### PR DESCRIPTION
Finds the '_x002e_', '_x0040_' and the '_<LookupAttributeName>_value' from the response and add the corresponding names.

lead_x002e_name -> lead.name
lead_x0040_name -> lead@name
_someAtribute_value -> someAtribute

It checks if the new attribute exists before adding it so it wont replace existing values.

It only add new attributes to the old ones won't be changed.

https://blogs.msdn.microsoft.com/crm/2016/02/16/onboarding-to-web-api-for-dynamics-crm-2016-from-web-api-preview/
https://msdn.microsoft.com/en-us/library/mt607533.aspx?f=255&MSPPError=-2147217396#Use%20custom%20FetchXML
